### PR TITLE
Require property directly from builder

### DIFF
--- a/src/Builders/Types/AbstractTypeBuilder.php
+++ b/src/Builders/Types/AbstractTypeBuilder.php
@@ -6,6 +6,7 @@ use FluentJsonSchema\Builders\TypeBuilder;
 use FluentJsonSchema\Concerns\FluentSchemaDTOAccessor;
 use FluentJsonSchema\FluentSchema;
 use FluentJsonSchema\Utility\Foreachable;
+use FluentJsonSchema\Utility\UtilityValue;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 
@@ -44,6 +45,13 @@ abstract class AbstractTypeBuilder implements FluentSchemaDTOAccessor
     public function enum(array $values): static
     {
         $this->fluentSchema->getSchemaDTO()->enum($values);
+
+        return $this;
+    }
+
+    public function required(bool $required = true): static
+    {
+        $this->fluentSchema->getSchemaDTO()->setUtilityValue(UtilityValue::IsPropertyRequired, $required);
 
         return $this;
     }

--- a/src/Builders/Types/ObjectBuilder.php
+++ b/src/Builders/Types/ObjectBuilder.php
@@ -81,7 +81,7 @@ class ObjectBuilder extends AbstractTypeBuilder
      */
     public function properties(array $properties): static
     {
-        foreach($properties as $name => $property) {
+        foreach ($properties as $name => $property) {
             $this->property($name, $property);
         }
 

--- a/src/Builders/Types/ObjectBuilder.php
+++ b/src/Builders/Types/ObjectBuilder.php
@@ -5,6 +5,7 @@ namespace FluentJsonSchema\Builders\Types;
 use FluentJsonSchema\Builders\FormatBuilder;
 use FluentJsonSchema\Concerns\FluentSchemaDTOAccessor;
 use FluentJsonSchema\FluentSchema;
+use FluentJsonSchema\Utility\UtilityValue;
 
 class ObjectBuilder extends AbstractTypeBuilder
 {
@@ -32,7 +33,7 @@ class ObjectBuilder extends AbstractTypeBuilder
      *
      * @return $this
      */
-    public function required(array $required): static
+    public function requiredProperties(array $required): static
     {
         $this->fluentSchema->getSchemaDTO()->required($required);
 
@@ -80,7 +81,9 @@ class ObjectBuilder extends AbstractTypeBuilder
      */
     public function properties(array $properties): static
     {
-        $this->fluentSchema->getSchemaDTO()->properties([...$this->fluentSchema->getSchemaDTO()->properties ?? [], ...$properties]);
+        foreach($properties as $name => $property) {
+            $this->property($name, $property);
+        }
 
         return $this;
     }
@@ -89,6 +92,10 @@ class ObjectBuilder extends AbstractTypeBuilder
     {
         if (!$property instanceof FluentSchema) {
             $property = $property->return();
+        }
+
+        if ($property->getSchemaDTO()->getUtilityValue(UtilityValue::IsPropertyRequired)) {
+            $this->fluentSchema->getSchemaDTO()->required([...$this->fluentSchema->getSchemaDTO()->required ?? [], $name]);
         }
 
         $this->fluentSchema->getSchemaDTO()->properties([...$this->fluentSchema->getSchemaDTO()->properties ?? [], $name => $property]);

--- a/src/FluentSchemaDTO.php
+++ b/src/FluentSchemaDTO.php
@@ -27,8 +27,8 @@ class FluentSchemaDTO
     use MetadataSchema;
     use MiscSchema;
     use UnevaluatedSchema;
-    use ValidationSchema;
     use UtilityContainer;
+    use ValidationSchema;
 
     /**
      * @var array<string, mixed>

--- a/src/FluentSchemaDTO.php
+++ b/src/FluentSchemaDTO.php
@@ -14,6 +14,7 @@ use FluentJsonSchema\RFC\UnevaluatedSchema;
 use FluentJsonSchema\RFC\ValidationSchema;
 use FluentJsonSchema\Utility\FluentSchemaDTOProxy;
 use FluentJsonSchema\Utility\UnserializedAttribute;
+use FluentJsonSchema\Utility\UtilityContainer;
 
 use function FluentJsonSchema\Utility\array_order_keys;
 
@@ -27,6 +28,7 @@ class FluentSchemaDTO
     use MiscSchema;
     use UnevaluatedSchema;
     use ValidationSchema;
+    use UtilityContainer;
 
     /**
      * @var array<string, mixed>
@@ -38,6 +40,9 @@ class FluentSchemaDTO
     private ?array $keyOrder;
     #[UnserializedAttribute]
     private FluentSchemaDTOProxy $proxy;
+
+    #[UnserializedAttribute]
+    private array $utilityContainer = [];
 
     public function setProxy(FluentSchemaDTOProxy $proxy): static
     {

--- a/src/Utility/UtilityContainer.php
+++ b/src/Utility/UtilityContainer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FluentJsonSchema\Utility;
+
+trait UtilityContainer
+{
+    public function setUtilityValue(UtilityValue $name, mixed $value): static
+    {
+        $this->utilityContainer[$name->name] = $value;
+
+        return $this;
+    }
+
+    public function getUtilityValue(UtilityValue $name): mixed
+    {
+        return $this->utilityContainer[$name->name];
+    }
+}

--- a/src/Utility/UtilityValue.php
+++ b/src/Utility/UtilityValue.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FluentJsonSchema\Utility;
+
+enum UtilityValue
+{
+    case IsPropertyRequired;
+}

--- a/tests/Unit/BuilderTest.php
+++ b/tests/Unit/BuilderTest.php
@@ -312,7 +312,7 @@ describe('array builder', function() {
 
 });
 
-describe('array builder', function() {
+describe('object builder', function() {
 
     test('maxProperties', function() {
         expect(FluentSchema::make()->type()->object()->maxProperties(10)->return()->compile())->toBe(['type' => 'object', 'maxProperties' => 10]);
@@ -323,7 +323,7 @@ describe('array builder', function() {
     });
 
     test('required', function() {
-        expect(FluentSchema::make()->type()->object()->required(['test1', 'test2'])->return()->compile())->toBe(['type' => 'object', 'required' => ['test1', 'test2']]);
+        expect(FluentSchema::make()->type()->object()->requiredProperties(['test1', 'test2'])->return()->compile())->toBe(['type' => 'object', 'required' => ['test1', 'test2']]);
     });
 
     test('dependentRequired', function() {
@@ -358,6 +358,10 @@ describe('array builder', function() {
         expect(FluentSchema::make()->type()->object()->propertyNames(FluentSchema::make()->type()->number()->return())->return()->compile())->toBe(['type' => 'object', 'propertyNames' => ['type' => 'number']]);
     });
 
+});
+
+test('can require object properties directly', function() {
+    expect(FluentSchema::make()->type()->object()->property('test1', FluentSchema::make()->type()->string()->required())->return()->compile())->toBe(['type' => 'object', 'required' => ['test1'], 'properties' => ['test1' => ['type' => 'string']]]);
 });
 
 test('array builder restricted values', function(string $method) {


### PR DESCRIPTION
Can now call `->required()` directly from within a property declaration

```php
FluentSchema::make()
  ->type()->object()
  ->property('test1', FluentSchema::make()
    ->type()->string()
    ->required()
  )
```

In object context, the `require` method was renamed to `requiredProperties`